### PR TITLE
fix quotes in img tag marked renderer override

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,3 @@ If your app config contains a `base_url` entry, then a `rss.xml` RSS feed is gen
 title: "My great post"
 date: "2021-09-02"
 ```
-
-Also, the feed items do not yet contain the contents of the posts.

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -168,7 +168,7 @@ function renderPageContentsForRSS(
   }
   renderer.image = (href, title, text) => {
     const absoluteHref = getLinkHref(href as string, appBaseURL);
-    return `<img src="${absoluteHref} alt=${text}">`;
+    return `<img src="${absoluteHref}" alt="${text}">`;
   }
   marked.setOptions({ renderer });
   return marked(page.contents);


### PR DESCRIPTION
Missing some quotes. Whoops!