### PR TITLE
Generate podcast feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,37 @@ If your app config contains a `base_url` entry, then a `rss.xml` RSS feed is gen
 title: "My great post"
 date: "2021-09-02"
 ```
+
+### Podcast RSS Feed
+
+Syte can also generate a podcast RSS feed with the required fields for the iTunes podcast directory. Here are the required fields in app config (with some examples):
+
+```
+title: My Awesome Podcast
+base_url: https://example.com
+podcast_category: Technology
+podcast_language: en-us
+podcast_subtitle: The greatest podcast of all time
+podcast_author: Jane Smith
+podcast_summary: The greatest podcast of all time, featuring Jane Smith
+podcast_explicit: 'no'
+podcast_email: foo@example.com
+podcast_img_url: https://example.com/logo.jpg
+```
+
+And each page will need the following frontmatter (with examples):
+
+```
+title: "1: This is an episode title"
+date: "2021-12-07"
+episode_url: 'https://example/audio/001_this_is_an_episode.mp3'
+episode_duration: '4960'
+episode_length: '99215166'
+episode_summary: This episode is about being awesome.
+episode_explict: 'yes'
+```
+
+The only slightly confusing fields here are likely `episode_duration` and `episode_length`. Episode duration refers to the length of your episode's mp3 file in seconds and can be calculated with this command `fprobe -show_entries stream=duration -of compact=p=0:nk=1 -v fatal MY_AWESOME_EPISODE.mp3`. Episode length refers to the number of bytes of your episode's mp3 file and can be calculated with `wc -c < MY_AWESOME_EPISODE.mp3`.
+
+The "show notes" for each episode will be generated from the page contents (after the frontmatter).
+

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -428,7 +428,6 @@ async function cmdBuild(argv: BuildCmdArgvType) {
             { "itunes:duration": page.context.episode_duration },
             { "itunes:summary": page.context.episode_summary },
             { "itunes:subtitle": page.context.episode_summary },
-            { "itunes:order": page.context.episode_number },
             { "itunes:explicit": page.context.episode_explict },
             {
               "itunes:image": {

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -346,8 +346,8 @@ async function cmdBuild(argv: BuildCmdArgvType) {
     const feed = new RSS({
       title: appContext.title,
       description: appContext.title,
-      feed_url: rssPath,
-      site_url: `${appContext.base_url}/${RSS_FILENAME}`,
+      feed_url: `${appContext.base_url}/${RSS_FILENAME}`,
+      site_url: appContext.base_url,
       pubDate: new Date(),
       ttl: 60,
     });
@@ -373,8 +373,8 @@ async function cmdBuild(argv: BuildCmdArgvType) {
       description: appContext.podcast_subtitle,
       categories: [appContext.podcast_category],
       language: appContext.podcast_language || "en-us",
-      feed_url: podcastRssPath,
-      site_url: `${appContext.base_url}/${PODCAST_RSS_FILENAME}`,
+      feed_url: `${appContext.base_url}/${PODCAST_RSS_FILENAME}`,
+      site_url: appContext.base_url,
       pubDate: new Date(),
       generator: "Syte",
       ttl: 60,

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -370,7 +370,7 @@ async function cmdBuild(argv: BuildCmdArgvType) {
     const podcastRssPath = path.join(outputPath, PODCAST_RSS_FILENAME);
     const feed = new RSS({
       title: appContext.title,
-      description: appContext.title,
+      description: appContext.podcast_subtitle,
       categories: [appContext.podcast_category],
       language: appContext.podcast_language || "en-us",
       feed_url: podcastRssPath,
@@ -411,17 +411,17 @@ async function cmdBuild(argv: BuildCmdArgvType) {
       ],
     });
     pages
-      .filter((page) => page.context.date && page.context.title && page.context.audio_url)
+      .filter((page) => page.context.date && page.context.title && page.context.episode_url)
       .sort((a, b) => new Date(b.context.date).getTime() - new Date(a.context.date).getTime())
       .map((page) => {
         const contents = renderPageContentsForRSS(page, appContext.base_url);
         feed.item({
-          title: page.context.podcastEpisodeTitle,
+          title: page.context.title,
           description: contents, // displays as "Show Notes"
           url: `${appContext.base_url}${page.urlPath}`,
           date: page.context.date,
           categories: [appContext.podcast_category],
-          enclosure: { url: page.context.podcastEpisodeURL },
+          enclosure: { url: page.context.episode_url, size: page.context.episode_length },
           custom_elements: [
             { "itunes:author": appContext.podcast_author },
             { "itunes:title": page.context.title },
@@ -429,7 +429,7 @@ async function cmdBuild(argv: BuildCmdArgvType) {
             { "itunes:summary": page.context.episode_summary },
             { "itunes:subtitle": page.context.episode_summary },
             { "itunes:order": page.context.episode_number },
-            { "itunes:explicit": page.context.episode_explicit },
+            { "itunes:explicit": page.context.episode_explict },
             {
               "itunes:image": {
                 _attr: {
@@ -452,7 +452,7 @@ async function cmdBuild(argv: BuildCmdArgvType) {
   const promises = [copyStatic(), ...buildPages()];
   if (appContext.base_url) {
     promises.push(buildRssFeed());
-    if (appContext.podcast) {
+    if (appContext.podcast_author) {
       promises.push(buildPodcastRssFeed());
     }
   }


### PR DESCRIPTION
This PR adds another RSS feed to blog output (if you add the required metadata and frontmatter), specifically designed for podcasts. I've added the required fields for iTunes podcast directory. There are other entries I can add later (for Google Store, etc), but this should be enough to "run your podcast" from Syte!

Todo:

- [x] get feed working and able to play in podcast player
- [x] fix validation errors
- [x] update README with required frontmatter, including commands to generate mp3 file metadata

Validation proof:

![Screen Shot 2021-12-07 at 9 00 48 AM](https://user-images.githubusercontent.com/482482/145073218-8720519f-b07c-46d4-9989-2c7134431489.png)
![Screen Shot 2021-12-07 at 9 00 40 AM](https://user-images.githubusercontent.com/482482/145073227-55be869d-1402-48e6-9065-08279c25722f.png)
